### PR TITLE
Implement Pid Tuning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(COMMON_SRC
     "Geometry2d/Segment.cpp"
     "multicast.cpp"
     "Pid.cpp"
+    "pidTuner.cpp"
     "Utils.cpp"
 )
 

--- a/Pid.cpp
+++ b/Pid.cpp
@@ -57,30 +57,30 @@ void Pid::clearWindup() {
     std::fill(_oldErr.begin(), _oldErr.end(), 0);
 }
 
-void Pid::initializeTuner(){
+void Pid::initializeTuner() {
     _tuner = make_unique<PidTuner>(kp,ki,kd);
 }
 
-void Pid::setFromTuner(){
+void Pid::setFromTuner() {
     kp = _tuner->getP();
     ki = _tuner->getI();
     kd = _tuner->getD();
 }
 
-void Pid::startTunerCycle(){
+void Pid::startTunerCycle() {
     _tuner->startCycle();
     setFromTuner();
 }
 
-void Pid::runTuner(){
+void Pid::runTuner() {
     _tuner->run(_lastErr);
 }
 
-bool Pid::endTunerCycle(){
-    if(_tuner->endCycle()){
+bool Pid::endTunerCycle() {
+    if(_tuner->endCycle()) {
         return true;
     }
-    else{
+    else {
         setFromTuner();
         return false;
     }

--- a/Pid.cpp
+++ b/Pid.cpp
@@ -1,3 +1,4 @@
+
 #include "Pid.hpp"
 
 #include <cmath>
@@ -55,3 +56,26 @@ void Pid::clearWindup() {
     _errSum = 0;
     std::fill(_oldErr.begin(), _oldErr.end(), 0);
 }
+
+void Pid::initialize_tuner(){
+    _tuner = new pidTuner(kp,ki,kd);
+}
+
+void Pid::start_cycle(){
+    _tuner->start_cycle();
+    kp = _tuner->getP();
+    ki = _tuner->getI();
+    kd = _tuner->getD();
+}
+
+void Pid::run(){
+    _tuner->run(_lastErr);
+}
+
+bool Pid::end_cycle(){
+    return _tuner->end_cycle();
+}
+
+
+
+

--- a/Pid.cpp
+++ b/Pid.cpp
@@ -61,11 +61,15 @@ void Pid::initialize_tuner(){
     _tuner = new pidTuner(kp,ki,kd);
 }
 
-void Pid::start_cycle(){
-    _tuner->start_cycle();
+void Pid::set_from_tuner(){
     kp = _tuner->getP();
     ki = _tuner->getI();
     kd = _tuner->getD();
+}
+
+void Pid::start_cycle(){
+    _tuner->start_cycle();
+    set_from_tuner();
 }
 
 void Pid::run(){
@@ -73,7 +77,13 @@ void Pid::run(){
 }
 
 bool Pid::end_cycle(){
-    return _tuner->end_cycle();
+    if(_tuner->end_cycle()){
+        return true;
+    }
+    else{
+        set_from_tuner();
+        return false;
+    }
 }
 
 

--- a/Pid.cpp
+++ b/Pid.cpp
@@ -57,31 +57,31 @@ void Pid::clearWindup() {
     std::fill(_oldErr.begin(), _oldErr.end(), 0);
 }
 
-void Pid::initialize_tuner(){
-    _tuner = new pidTuner(kp,ki,kd);
+void Pid::initializeTuner(){
+    _tuner = make_unique<PidTuner>(kp,ki,kd);
 }
 
-void Pid::set_from_tuner(){
+void Pid::setFromTuner(){
     kp = _tuner->getP();
     ki = _tuner->getI();
     kd = _tuner->getD();
 }
 
-void Pid::start_cycle(){
-    _tuner->start_cycle();
-    set_from_tuner();
+void Pid::startTunerCycle(){
+    _tuner->startCycle();
+    setFromTuner();
 }
 
-void Pid::run(){
+void Pid::runTuner(){
     _tuner->run(_lastErr);
 }
 
-bool Pid::end_cycle(){
-    if(_tuner->end_cycle()){
+bool Pid::endTunerCycle(){
+    if(_tuner->endCycle()){
         return true;
     }
     else{
-        set_from_tuner();
+        setFromTuner();
         return false;
     }
 }

--- a/Pid.cpp
+++ b/Pid.cpp
@@ -79,13 +79,8 @@ void Pid::runTuner() {
 bool Pid::endTunerCycle() {
     if(_tuner->endCycle()) {
         return true;
-    }
-    else {
+    } else {
         setFromTuner();
         return false;
     }
 }
-
-
-
-

--- a/Pid.hpp
+++ b/Pid.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <vector>
+#include <memory>
 #include "pidTuner.hpp"
 
 class Pid {
@@ -18,14 +19,11 @@ public:
     void clearWindup();
 
 
-    //tuner stuff
-    void initialize_tuner();
-
-    void set_from_tuner();
-
-    void start_cycle();
-    void run();
-    bool end_cycle();
+    //Pid Tuning Functions
+    void initializeTuner();
+    void startTunerCycle();
+    void runTuner();
+    bool endTunerCycle();
 
 
     float kp, ki, kd;
@@ -43,5 +41,6 @@ private:
 
     std::vector<float> _oldErr;
 
-    pidTuner* _tuner;
+    std::unique_ptr <PidTuner> _tuner;
+    void setFromTuner();
 };

--- a/Pid.hpp
+++ b/Pid.hpp
@@ -21,6 +21,8 @@ public:
     //tuner stuff
     void initialize_tuner();
 
+    void set_from_tuner();
+
     void start_cycle();
     void run();
     bool end_cycle();

--- a/Pid.hpp
+++ b/Pid.hpp
@@ -1,8 +1,10 @@
 #pragma once
 #include <vector>
+#include "pidTuner.hpp"
 
 class Pid {
 public:
+
     Pid(float p = 0, float i = 0, float d = 0, unsigned int windup = 0);
 
     unsigned int windup() const { return _windup; }
@@ -15,11 +17,18 @@ public:
     /** clear any windup */
     void clearWindup();
 
+
+    //tuner stuff
+    void initialize_tuner();
+
+    void start_cycle();
+    void run();
+    bool end_cycle();
+
+
     float kp, ki, kd;
 
 private:
-    Pid(Pid&);
-    Pid& operator&=(Pid&);
 
     /** amount to sum up */
     unsigned int _windup;
@@ -31,4 +40,6 @@ private:
     float _lastErr;
 
     std::vector<float> _oldErr;
+
+    pidTuner* _tuner;
 };

--- a/pidTuner.cpp
+++ b/pidTuner.cpp
@@ -85,8 +85,7 @@ bool PidTuner::endCycle() {
         }
 
         //Find the set with the lowest score
-        _bestPid = *(std::min_element(std::begin(_testSets),std::end(_testSets),
-            [] (PidSet const& p1, PidSet const& p2){ return p1.score < p2.score;}));
+        _bestPid = *(std::min_element(std::begin(_testSets),std::end(_testSets)));
 
         //Don't actually need to include bestPid in testSet
         _testSets.pop_back();

--- a/pidTuner.cpp
+++ b/pidTuner.cpp
@@ -50,8 +50,10 @@ void PidTuner::run(float err) {
 bool PidTuner::endCycle() {
     _testSets[_testNum] = _currentPid;
     _testNum += 1;
-
+    std::cout<<_currentPid.p<<" | "<<_currentPid.i<<" | "<<_currentPid.d<<std::endl;
+    std::cout<<_currentPid.score<<std::endl;
     if(_testNum==_testSets.size()) {
+        std::cout<<"---------------------------"<<std::endl;
         //finished testing set, determine best pid, then check if we need more tests
         _cycles += 1;
 

--- a/pidTuner.cpp
+++ b/pidTuner.cpp
@@ -18,6 +18,8 @@ PidTuner::PidTuner(float ip, float ii, float id, float Sp, float Si, float Sd){
     _overScale = 1;
 
     _threshold = .5;
+
+    _overScale = 2; //the step is divided by overscale each time it overshoots the target
 }
 
 PidTuner::PidSet::PidSet(float ip, float ii, float id){
@@ -58,12 +60,6 @@ bool PidTuner::endCycle(){
         bestPid = *(std::min_element(std::begin(_testSets),std::end(_testSets),
             [] (PidSet const& p1, PidSet const& p2){ return p1.score < p2.score;}));
 
-        if(bestPid == _testSets[0]){
-            _overScale = 2;
-        }
-        else{
-            _overScale = 1;
-        }
 
         _pScale *= _testSets[0].score > _testSets[1].score ? 1 : -1/_overScale;
         _iScale *= _testSets[0].score > _testSets[2].score ? 1 : -1/_overScale;

--- a/pidTuner.cpp
+++ b/pidTuner.cpp
@@ -37,17 +37,17 @@ void PidTuner::startCycle() {
         _testSets.push_back(_currentPid);
 
         _testSets.push_back(PidSet(_currentPid.p + _pScale, _currentPid.i, _currentPid.d));
-        if(_currentPid.p - _pScale >= 0){
+        if(_currentPid.p - _pScale >= 0) {
             _testSets.push_back(PidSet(_currentPid.p - _pScale, _currentPid.i, _currentPid.d));
         }
 
         _testSets.push_back(PidSet(_currentPid.p, _currentPid.i + _iScale, _currentPid.d));
-        if( _currentPid.i - _iScale > 0){
+        if( _currentPid.i - _iScale > 0) {
             _testSets.push_back(PidSet(_currentPid.p, _currentPid.i - _iScale, _currentPid.d));
         }
 
         _testSets.push_back(PidSet(_currentPid.p, _currentPid.i, _currentPid.d + _dScale));
-        if( _currentPid.d - _dScale > 0){
+        if( _currentPid.d - _dScale > 0) {
             _testSets.push_back(PidSet(_currentPid.p, _currentPid.i, _currentPid.d - _dScale));
         }
 
@@ -65,10 +65,13 @@ void PidTuner::run(float err) {
 bool PidTuner::endCycle() {
     _testSets[_testNum] = _currentPid;
     _testNum += 1;
+
     std::cout<<_currentPid.p<<" | "<<_currentPid.i<<" | "<<_currentPid.d<<std::endl;
     std::cout<<_currentPid.score<<std::endl;
+
     if(_testNum==_testSets.size()) {
         std::cout<<"---------------------------"<<std::endl;
+
         //finished testing set, determine best pid, then check if we need more tests
         _cycles += 1;
 
@@ -88,6 +91,7 @@ bool PidTuner::endCycle() {
         //Don't actually need to include bestPid in testSet
         _testSets.pop_back();
 
+        //Scales the test step down and reverses the direction
         //_pScale *= _testSets[0].score > _testSets[1].score ? 1 : -1/_overScale;
         //_iScale *= _testSets[0].score > _testSets[2].score ? 1 : -1/_overScale;
         //_dScale *= _testSets[0].score > _testSets[3].score ? 1 : -1/_overScale;

--- a/pidTuner.cpp
+++ b/pidTuner.cpp
@@ -1,0 +1,57 @@
+#include "pidTuner.hpp"
+#include <iostream>
+#include <math.h>
+
+pidTuner::pidTuner(float ip, float ii, float id, float Sp, float Si, float Sd){
+    _initial_pid = pid_set(ip,ii,id);
+    _cycles = 0;
+
+    _pScale = Sp;
+    _iScale = Si;
+    _dScale = Sd;
+}
+
+pidTuner::pid_set::pid_set(float ip, float ii, float id){
+    p=ip;
+    i=ii;
+    d=id;
+    score=0;
+}
+
+void pidTuner::start_cycle(){
+    std::cout<<"C++: Start Cycle"<<std::endl;
+
+    pid_set _pid = _initial_pid;
+
+    //Initial Test Points,Tests current constants then produces cube centered on initial PID with sidelength of 2*_scale
+    if(1 <= _cycles && _cycles <= 8){
+        _cycles--;
+        if(_cycles>3)
+            _pid.p += _pScale;
+        else
+            _pid.p -= _pScale;
+        if(_cycles%4 >= 2)
+            _pid.d += _iScale;
+        else
+            _pid.d -= _iScale;
+        if(_cycles%2)
+            _pid.i += _dScale;
+        else
+            _pid.i -= _dScale;
+        _cycles++;
+    }
+    std::cout<<"C++ CYCLE: "<<_cycles<<" : "<<_pid.p<<" , "<<_pid.i<<" , "<<_pid.d<<std::endl;
+    _current_pid = _pid;
+}
+
+void pidTuner::run(float err){
+    _current_pid.score+=fabs(err);
+}
+
+//cleans up and returns if pid needs more tuning
+bool pidTuner::end_cycle(){
+    std::cout<<"C++: End CYCLE: "<<_current_pid.score<<std::endl;
+    _pid_sets.push_back(_current_pid);
+    _cycles+=1;
+    return true;
+}

--- a/pidTuner.cpp
+++ b/pidTuner.cpp
@@ -4,7 +4,7 @@
 #include <algorithm>
 
 
-PidTuner::PidTuner(float ip, float ii, float id, float Sp, float Si, float Sd){
+PidTuner::PidTuner(float ip, float ii, float id, float Sp, float Si, float Sd) {
     _initialPid = PidSet(ip,ii,id);
     _currentPid =  _initialPid;
 
@@ -22,16 +22,16 @@ PidTuner::PidTuner(float ip, float ii, float id, float Sp, float Si, float Sd){
     _overScale = 2; //the step is divided by overscale each time it overshoots the target
 }
 
-PidTuner::PidSet::PidSet(float ip, float ii, float id){
+PidTuner::PidSet::PidSet(float ip, float ii, float id) {
     p=ip;
     i=ii;
     d=id;
     score=0;
 }
 
-void PidTuner::startCycle(){
+void PidTuner::startCycle() {
     //if old test set is done, determine new values to test
-    if(_testNum==_testSets.size()){
+    if(_testNum==_testSets.size()) {
         _testSets.clear();
         _testSets.push_back(PidSet(_currentPid.p, _currentPid.i, _currentPid.d));
         _testSets.push_back(PidSet(_currentPid.p + _pScale, _currentPid.i, _currentPid.d));
@@ -42,16 +42,16 @@ void PidTuner::startCycle(){
     _currentPid = _testSets[_testNum];
 }
 
-void PidTuner::run(float err){
+void PidTuner::run(float err) {
     _currentPid.score += fabs(err);
 }
 
 //returns if pid needs more tuning, if it does, sets up next test points
-bool PidTuner::endCycle(){
+bool PidTuner::endCycle() {
     _testSets[_testNum] = _currentPid;
     _testNum += 1;
 
-    if(_testNum==_testSets.size()){
+    if(_testNum==_testSets.size()) {
         //finished testing set, determine best pid, then check if we need more tests
         _cycles+=1;
 
@@ -67,16 +67,15 @@ bool PidTuner::endCycle(){
 
         _currentPid = PidSet(_testSets[0].p + _pScale, _testSets[0].i + _iScale, _testSets[0].d + _dScale);
 
-        //make sure we have a prev score
-        if(_cycles > 1 && _prevScore - bestPid.score < _threshold){
+        //make sure we have a prev score, then check how much the score improved by
+        if(_cycles > 1 && _prevScore - bestPid.score < _threshold) {
             _currentPid = bestPid;
             return false; //Finished tuning
-        }
-        else{
+        } else {
             _prevScore = bestPid.score;
             return true; //keep testing
         }
-    } else{
+    } else {
         return true; //keep testing
     }
 }

--- a/pidTuner.cpp
+++ b/pidTuner.cpp
@@ -48,7 +48,6 @@ void pidTuner::start_cycle(){
                     _pid.d += _dScale;
                     break;
                 }
-                //std::cout<<_pid.p<<" "<<_pid.i<<" "<<_pid.d<<std::endl;
                 _test_sets.push_back(_pid);
         }
 
@@ -65,7 +64,6 @@ void pidTuner::run(float err){
 bool pidTuner::end_cycle(){
     //score old value
     _test_sets[_test_num] = _current_pid;
-    //std::cout<<"test set #"<<_test_num<<" set to: "<<_current_pid.score<<std::endl;
 
     _test_num += 1;
 
@@ -76,15 +74,12 @@ bool pidTuner::end_cycle(){
 
         pid_set _best_pid = _test_sets[0];
         for(int i=0; i<_test_sets.size();i++){
-            if(_test_sets[i].score<_current_pid.score){
+            if(_test_sets[i].score<_best_pid.score){
                 _best_pid = _test_sets[i];
             }
         }
 
-        //std::cout<<"best pid: "<<_best_pid.p<<" "<<_best_pid.i<<" "<<_best_pid.d<<" : "<<_best_pid.score<<std::endl;
-
         if(_best_pid == _test_sets[0]){
-            //std::cout<<"Reverse"<<std::endl;
             _overScale = 2;
         }
         else{
@@ -96,8 +91,6 @@ bool pidTuner::end_cycle(){
         _dScale *= _test_sets[0].score > _test_sets[3].score ? 1 : -1/_overScale;
 
         _current_pid = pid_set(_test_sets[0].p + _pScale, _test_sets[0].i + _iScale, _test_sets[0].d + _dScale);
-
-        //std::cout<<"HILL: "<<_pScale<<" "<<_iScale<<" "<<_dScale<<std::endl;
 
         //make sure we have a prev score
         if(_cycles > 1 && _prev_score - _best_pid.score < _threshold){

--- a/pidTuner.cpp
+++ b/pidTuner.cpp
@@ -53,7 +53,7 @@ bool PidTuner::endCycle() {
 
     if(_testNum==_testSets.size()) {
         //finished testing set, determine best pid, then check if we need more tests
-        _cycles+=1;
+        _cycles += 1;
 
 
         PidSet bestPid = _testSets[0];

--- a/pidTuner.hpp
+++ b/pidTuner.hpp
@@ -39,7 +39,7 @@ public:
 
 private:
 
-    /** Struct to store P, I and D values, also stores a score of the error */
+    //Struct to store P, I and D values and a score of the error
     struct PidSet {
         PidSet(float ip = 0, float ii = 0, float id = 0);
         inline bool operator==(const PidSet& pidIn) {
@@ -60,8 +60,6 @@ private:
     float _pScale;
     float _iScale;
     float _dScale;
-
-    float _overScale;
 
     float _prevScore;
 

--- a/pidTuner.hpp
+++ b/pidTuner.hpp
@@ -1,0 +1,39 @@
+#pragma once
+#include <vector>
+
+class pidTuner {
+public:
+
+    pidTuner(float ip, float ii, float id, float Sp=1, float Si=.1, float Sd=.05);
+
+    void start_cycle();
+    void run(float err);
+    bool end_cycle();
+
+    float getP(){ return _current_pid.p; }
+    float getI(){ return _current_pid.i; }
+    float getD(){ return _current_pid.d; }
+
+private:
+
+    struct pid_set {
+        pid_set(float ip=0, float ii=0, float id=0);
+        float p;
+        float i;
+        float d;
+        float score;
+    };
+
+    pid_set _initial_pid;
+    pid_set _current_pid;
+
+    int _cycles;
+
+    float _pScale;
+    float _iScale;
+    float _dScale;
+
+    std::vector <pid_set> _pid_sets;
+
+};
+

--- a/pidTuner.hpp
+++ b/pidTuner.hpp
@@ -13,7 +13,7 @@ public:
      *@param Si The step used for I
      *@param Sd The step used for D
      */
-    PidTuner(float ip, float ii, float id, float Sp=.5, float Si=.05, float Sd=.01);
+    PidTuner(float ip, float ii, float id, float Sp = .5, float Si = .05, float Sd = .01);
 
     /** Starts a cycle to test a PID value
      *  Call Once at the beginning of a test cycle
@@ -38,7 +38,7 @@ private:
 
     /** Struct to store P, I and D values, also stores a score of the error */
     struct PidSet {
-        PidSet(float ip=0, float ii=0, float id=0);
+        PidSet(float ip = 0, float ii = 0, float id = 0);
         inline bool operator==(const PidSet& pidIn) {
             return (p == pidIn.p) && (i == pidIn.i) && (d == pidIn.d);
         }

--- a/pidTuner.hpp
+++ b/pidTuner.hpp
@@ -16,7 +16,7 @@ public:
      *@param Si The step used for I
      *@param Sd The step used for D
      */
-    PidTuner(float ip, float ii, float id, float Sp = .5, float Si = .05, float Sd = .01);
+    PidTuner(float ip, float ii, float id, float Sp = .25, float Si = .01, float Sd = .005);
 
     /** @brief Starts a cycle to test a PID value
      *  @details Call Once at the beginning of a test cycle

--- a/pidTuner.hpp
+++ b/pidTuner.hpp
@@ -45,6 +45,9 @@ private:
         inline bool operator==(const PidSet& pidIn) {
             return (p == pidIn.p) && (i == pidIn.i) && (d == pidIn.d);
         }
+        inline bool operator<(const PidSet& pidIn) {
+          return (score < pidIn.score);
+        }
         float p;
         float i;
         float d;
@@ -68,4 +71,3 @@ private:
 
     std::vector <PidSet> _testSets;
 };
-

--- a/pidTuner.hpp
+++ b/pidTuner.hpp
@@ -4,7 +4,7 @@
 class pidTuner {
 public:
 
-    pidTuner(float ip, float ii, float id, float Sp=1, float Si=.1, float Sd=.05);
+    pidTuner(float ip, float ii, float id, float Sp=.5, float Si=.05, float Sd=.01);
 
     void start_cycle();
     void run(float err);
@@ -27,11 +27,17 @@ private:
     pid_set _initial_pid;
     pid_set _current_pid;
 
+    pid_set _hill_vector;
+
     int _cycles;
 
     float _pScale;
     float _iScale;
     float _dScale;
+
+    float _errThreshold;
+
+    float _minScore;
 
     std::vector <pid_set> _pid_sets;
 

--- a/pidTuner.hpp
+++ b/pidTuner.hpp
@@ -1,25 +1,46 @@
 #pragma once
 #include <vector>
 
-class pidTuner {
+class PidTuner {
 public:
 
-    pidTuner(float ip, float ii, float id, float Sp=.5, float Si=.05, float Sd=.01);
+    /**
+     *@Brief Constructs a new PidTuner
+     *@param ip The starting P value
+     *@param ii The starting I value
+     *@param id The starting D value
+     *@param Sp The step used for P
+     *@param Si The step used for I
+     *@param Sd The step used for D
+     */
+    PidTuner(float ip, float ii, float id, float Sp=.5, float Si=.05, float Sd=.01);
 
-    void start_cycle();
+    /** Starts a cycle to test a PID value
+     *  Call Once at the beginning of a test cycle
+     */
+    void startCycle();
+
+    /** Adds the error to the total score of the current PID set
+     *  Call once each frame during a PID test
+     */
     void run(float err);
-    bool end_cycle();
 
-    float getP(){ return _current_pid.p; }
-    float getI(){ return _current_pid.i; }
-    float getD(){ return _current_pid.d; }
+    /** Ends the test of a PID value, returns True if more tuning is needed
+     *  Call Once at the end of a test cycle
+     */
+    bool endCycle();
+
+    float getP(){ return _currentPid.p; }
+    float getI(){ return _currentPid.i; }
+    float getD(){ return _currentPid.d; }
 
 private:
 
-    struct pid_set {
-        pid_set(float ip=0, float ii=0, float id=0);
-        inline bool operator==(const pid_set& pid_in){
-            return (p == pid_in.p) && (i == pid_in.i) && (d == pid_in.d);
+    /** Struct to store P, I and D values, also stores a score of the error */
+    struct PidSet {
+        PidSet(float ip=0, float ii=0, float id=0);
+        inline bool operator==(const PidSet& pidIn){
+            return (p == pidIn.p) && (i == pidIn.i) && (d == pidIn.d);
         }
         float p;
         float i;
@@ -27,13 +48,11 @@ private:
         float score;
     };
 
-    pid_set _initial_pid;
-    pid_set _current_pid;
-
-    pid_set _hill_vector;
+    PidSet _initialPid;
+    PidSet _currentPid;
 
     int _cycles;
-    int _test_num;
+    int _testNum;
 
     float _pScale;
     float _iScale;
@@ -41,11 +60,10 @@ private:
 
     float _overScale;
 
-    float _prev_score;
+    float _prevScore;
 
     float _threshold;
 
-    std::vector <pid_set> _test_sets;
-
+    std::vector <PidSet> _testSets;
 };
 

--- a/pidTuner.hpp
+++ b/pidTuner.hpp
@@ -18,6 +18,9 @@ private:
 
     struct pid_set {
         pid_set(float ip=0, float ii=0, float id=0);
+        inline bool operator==(const pid_set& pid_in){
+            return (p == pid_in.p) && (i == pid_in.i) && (d == pid_in.d);
+        }
         float p;
         float i;
         float d;
@@ -30,16 +33,20 @@ private:
     pid_set _hill_vector;
 
     int _cycles;
+    int _test_num;
 
     float _pScale;
     float _iScale;
     float _dScale;
+
+    float _overScale;
 
     float _errThreshold;
 
     float _minScore;
 
     std::vector <pid_set> _pid_sets;
+    std::vector <pid_set> _test_sets;
 
 };
 

--- a/pidTuner.hpp
+++ b/pidTuner.hpp
@@ -30,16 +30,16 @@ public:
      */
     bool endCycle();
 
-    float getP(){ return _currentPid.p; }
-    float getI(){ return _currentPid.i; }
-    float getD(){ return _currentPid.d; }
+    float getP() { return _currentPid.p; }
+    float getI() { return _currentPid.i; }
+    float getD() { return _currentPid.d; }
 
 private:
 
     /** Struct to store P, I and D values, also stores a score of the error */
     struct PidSet {
         PidSet(float ip=0, float ii=0, float id=0);
-        inline bool operator==(const PidSet& pidIn){
+        inline bool operator==(const PidSet& pidIn) {
             return (p == pidIn.p) && (i == pidIn.i) && (d == pidIn.d);
         }
         float p;

--- a/pidTuner.hpp
+++ b/pidTuner.hpp
@@ -41,11 +41,10 @@ private:
 
     float _overScale;
 
-    float _errThreshold;
+    float _prev_score;
 
-    float _minScore;
+    float _threshold;
 
-    std::vector <pid_set> _pid_sets;
     std::vector <pid_set> _test_sets;
 
 };

--- a/pidTuner.hpp
+++ b/pidTuner.hpp
@@ -16,7 +16,7 @@ public:
      *@param Si The step used for I
      *@param Sd The step used for D
      */
-    PidTuner(float ip, float ii, float id, float Sp = .25, float Si = .01, float Sd = .005);
+    PidTuner(float ip, float ii, float id, float Sp = .1, float Si = .1, float Sd = .1);
 
     /** @brief Starts a cycle to test a PID value
      *  @details Call Once at the beginning of a test cycle
@@ -53,6 +53,7 @@ private:
 
     PidSet _initialPid;
     PidSet _currentPid;
+    PidSet _bestPid;
 
     int _cycles;
     int _testNum;
@@ -60,8 +61,6 @@ private:
     float _pScale;
     float _iScale;
     float _dScale;
-
-    float _prevScore;
 
     float _threshold;
 

--- a/pidTuner.hpp
+++ b/pidTuner.hpp
@@ -64,6 +64,8 @@ private:
 
     float _threshold;
 
+    float _overScale;
+
     std::vector <PidSet> _testSets;
 };
 

--- a/pidTuner.hpp
+++ b/pidTuner.hpp
@@ -1,11 +1,14 @@
 #pragma once
 #include <vector>
 
+/**
+Class contained by Pid to automatically tune PID Coefficients
+*/
 class PidTuner {
 public:
 
     /**
-     *@Brief Constructs a new PidTuner
+     *@brief Constructs a new PidTuner
      *@param ip The starting P value
      *@param ii The starting I value
      *@param id The starting D value
@@ -15,18 +18,18 @@ public:
      */
     PidTuner(float ip, float ii, float id, float Sp = .5, float Si = .05, float Sd = .01);
 
-    /** Starts a cycle to test a PID value
-     *  Call Once at the beginning of a test cycle
+    /** @brief Starts a cycle to test a PID value
+     *  @details Call Once at the beginning of a test cycle
      */
     void startCycle();
 
-    /** Adds the error to the total score of the current PID set
-     *  Call once each frame during a PID test
+    /** @brief Adds the error to the total score of the current PID set
+     *  @details Call Once each frame during a PID test
      */
     void run(float err);
 
-    /** Ends the test of a PID value, returns True if more tuning is needed
-     *  Call Once at the end of a test cycle
+    /** @brief Ends the test of a PID value, returns True if more tuning is needed
+     *  @details Call Once at the end of a test cycle
      */
     bool endCycle();
 


### PR DESCRIPTION
The common portion of [#887](https://github.com/RoboJackets/robocup-software/pull/887 "Tune PID automatically"). Adds a Pid Tuner class that is contained inside Pid to tune it. 
Closes [#291](https://github.com/RoboJackets/robocup-software/issues/291 "Use genetic algorithms for tuning motion control parameters").

TODO:
- [x]  Implement the algorithm to decide on new values to test
- [x]  Determine if the tuner needs to account for "noise" in the pid function
- [x]  Figure out when to stop tuning
- [x]  Make graphs
- [x]  Remove debug print statements and unnecessary comments