### PR TITLE
Try to improve performance of nearestPoint

### DIFF
--- a/Geometry2d/Segment.cpp
+++ b/Geometry2d/Segment.cpp
@@ -96,10 +96,10 @@ bool Segment::nearPoint(const Point& point, float threshold) const {
 Point Segment::nearestPoint(const Point& p) const {
     // http://stackoverflow.com/a/1501725
 
-    const float magsq = delta().magsq();
+    const double magsq = delta().magsq();
     if (magsq == 0) return pt[0];
 
-    float t = delta().dot(p - pt[0]) / magsq;
+    const double t = delta().dot(p - pt[0]) / magsq;
 
     if (t <= 0) {
         return pt[0];


### PR DESCRIPTION
I did a profile and it turns out geometry2d functions are where we're spending the most time in (probably because they're being called a lot everywhere). 

Here's some profiles I did of adaptiveFormation, but the profile looks similar elsewhere as well:

Before: 
[perf.log](https://github.com/RoboJackets/robocup-common/files/1629771/perf.log)

After: 
[perf.post.log](https://github.com/RoboJackets/robocup-common/files/1629772/perf.post.log)


There was an instruction converting the floats here into doubles which was very hot, and just operating on doubles removes that bottleneck. Not a huge fix but it's a small start.

At some point we need to figure out if there's a faster way to run this function from a logic point of view.